### PR TITLE
changes in gradle to be able to build after adding page viewer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@
 
 buildscript {
     repositories {
+        maven { url "http://dl.bintray.com/populov/maven" }
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -14,6 +16,7 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { url "http://dl.bintray.com/populov/maven" }
         jcenter()
     }
 }

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -32,6 +32,6 @@ dependencies {
     compile 'com.android.support:appcompat-v7:21.0.3'
     compile 'com.google.android.gms:play-services:6.5.87'
     compile 'com.jakewharton:butterknife:6.1.0'
-    compile 'com.viewpagerindicator:library:2.4.1'
+    compile 'com.viewpagerindicator:library:2.4.1@aar'
 
 }


### PR DESCRIPTION
Hey @vladoatanasov @jessyconroy 
My gradle would not sync complaining about apklib not being supported after the addition of the pager indicator. I fixed it as per the diff but I don't know if it's just my setup or is it needed?
